### PR TITLE
perf(storage): tune Parquet and flusher settings for Iceberg

### DIFF
--- a/src/flusher/mod.rs
+++ b/src/flusher/mod.rs
@@ -47,6 +47,12 @@ impl FlusherConfig {
     /// - Target 64-256MB Parquet files for optimal query performance
     /// - 5-minute flush interval for low-volume tables to accumulate data
     /// - Size-based batching via target_file_size_bytes
+    ///
+    /// # Durability
+    ///
+    /// The 5-minute flush interval means up to 5 minutes of data may be lost
+    /// on crash (WAL is disabled for throughput). For tighter durability
+    /// guarantees, override with `ZOMBI_FLUSH_INTERVAL_SECS` environment variable.
     pub fn iceberg_defaults() -> Self {
         Self {
             interval: Duration::from_secs(300), // 5 minutes for low-volume tables


### PR DESCRIPTION
## Summary

- Configure ZSTD compression for Parquet files
- Set row group size to 1M rows to minimize metadata overhead
- Increase flush interval to 5 minutes for low-volume tables in Iceberg mode
- Document batch_size field as advisory

## Tests Added

- `test_larger_batches_compress_better` - Verifies larger batches have better bytes-per-event ratio
- `test_parquet_uses_zstd_compression` - Reads Parquet metadata to verify ZSTD codec
- `test_row_group_size_is_reasonable` - Verifies row group configuration works
- `test_compression_effectiveness` - Verifies compressed size < raw payload size

## Test Plan

- [x] All 105 tests pass
- [x] Clippy passes with no warnings
- [x] `cargo fmt --check` passes

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)