### PR TITLE
feat(api): add memory backpressure for write path

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -329,6 +329,9 @@ Redis stores:
 | `ZOMBI_CATALOG_TYPE` | `filesystem` | `filesystem` or `rest` |
 | `ZOMBI_CATALOG_URL` | - | REST catalog URL |
 | `ZOMBI_CATALOG_NAMESPACE` | `zombi` | Iceberg namespace |
+| **Backpressure** |
+| `ZOMBI_MAX_INFLIGHT_WRITES` | `10000` | Max concurrent writes |
+| `ZOMBI_MAX_INFLIGHT_BYTES_MB` | `64` | Max inflight bytes (MB) |
 | **Scaling** |
 | `ZOMBI_REDIS_URL` | - | Redis URL (enables multi-node) |
 | `ZOMBI_NODE_ID` | `auto` | Unique node identifier |

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,7 +8,9 @@ use axum::Router;
 
 use crate::contracts::{ColdStorage, HotStorage};
 
-pub use handlers::{AppState, Metrics, NoopColdStorage, WriteRecordRequest, WriteRecordResponse};
+pub use handlers::{
+    AppState, BackpressureConfig, Metrics, NoopColdStorage, WriteRecordRequest, WriteRecordResponse,
+};
 
 /// Creates the API router.
 pub fn create_router<H: HotStorage + 'static, C: ColdStorage + 'static>(

--- a/src/contracts/error.rs
+++ b/src/contracts/error.rs
@@ -63,6 +63,9 @@ pub enum StorageError {
 
     #[error("IO error: {0}")]
     Io(String),
+
+    #[error("Server overloaded: {0}")]
+    Overloaded(String),
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
## Summary

- Add `StorageError::Overloaded` variant for backpressure errors
- Add `BackpressureConfig` with `max_inflight_writes` (default: 10,000) and `max_inflight_bytes` (default: 64MB)
- Add semaphore-based write limiting in `AppState` using `try_acquire_write_permit`
- Return 503 Service Unavailable when server is overloaded
- Add `ZOMBI_MAX_INFLIGHT_WRITES` and `ZOMBI_MAX_INFLIGHT_BYTES_MB` environment variables

## Test plan

- [x] All existing tests pass
- [x] New integration test `test_backpressure_bytes_limit` verifies 503 response
- [x] `cargo clippy` passes

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)