### PR TITLE
perf(iceberg): batch Iceberg snapshots to reduce metadata churn

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -323,6 +323,8 @@ Redis stores:
 | `ZOMBI_ICEBERG_ENABLED` | `true` | Enable Iceberg output |
 | `ZOMBI_TARGET_FILE_SIZE_MB` | `128` | Target Parquet file size (flush) |
 | `ZOMBI_COMPACTED_FILE_SIZE_MB` | `512` | Target file size after compaction |
+| `ZOMBI_SNAPSHOT_THRESHOLD_FILES` | `10` | Min files before snapshot commit |
+| `ZOMBI_SNAPSHOT_THRESHOLD_GB` | `1` | Min GB before snapshot commit |
 | `ZOMBI_FLUSH_INTERVAL_SECS` | `30` | Flush interval |
 | `ZOMBI_FLUSH_MIN_EVENTS` | `10000` | Min events before flush |
 | **Catalog** |

--- a/src/contracts/cold_storage.rs
+++ b/src/contracts/cold_storage.rs
@@ -18,6 +18,15 @@ pub struct ColdStorageInfo {
     pub base_path: String,
 }
 
+/// Statistics about pending files for a topic, awaiting snapshot commit.
+#[derive(Debug, Clone, Default)]
+pub struct PendingSnapshotStats {
+    /// Number of pending data files
+    pub file_count: usize,
+    /// Total bytes across pending files
+    pub total_bytes: u64,
+}
+
 /// Cold storage for archived events (S3).
 ///
 /// Events are written in batches as log segments.
@@ -65,6 +74,12 @@ pub trait ColdStorage: Send + Sync {
         _topic: &str,
     ) -> impl Future<Output = Result<Option<i64>, StorageError>> + Send {
         async move { Ok(None) }
+    }
+
+    /// Returns statistics about pending files awaiting snapshot commit.
+    /// Used for batched snapshot logic.
+    fn pending_snapshot_stats(&self, _topic: &str) -> PendingSnapshotStats {
+        PendingSnapshotStats::default()
     }
 }
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -4,7 +4,7 @@ pub mod flusher;
 pub mod sequence;
 pub mod storage;
 
-pub use cold_storage::{ColdStorage, ColdStorageInfo, SegmentInfo};
+pub use cold_storage::{ColdStorage, ColdStorageInfo, PendingSnapshotStats, SegmentInfo};
 pub use error::{LockResultExt, SequenceError, StorageError, ZombiError};
 pub use flusher::{FlushResult, Flusher};
 pub use sequence::SequenceGenerator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 .map(|mb| mb * 1024 * 1024)
                 .unwrap_or(base_config.target_file_size_bytes),
             iceberg_enabled,
+            snapshot_threshold_files: std::env::var("ZOMBI_SNAPSHOT_THRESHOLD_FILES")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(base_config.snapshot_threshold_files),
+            snapshot_threshold_bytes: std::env::var("ZOMBI_SNAPSHOT_THRESHOLD_GB")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .map(|gb| gb * 1024 * 1024 * 1024)
+                .unwrap_or(base_config.snapshot_threshold_bytes),
         };
 
         if iceberg_enabled {
@@ -110,7 +119,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 batch_size = config.batch_size,
                 max_segment_size = config.max_segment_size,
                 target_file_size_mb = config.target_file_size_bytes / (1024 * 1024),
-                "Iceberg mode enabled - using optimized flush settings"
+                snapshot_threshold_files = config.snapshot_threshold_files,
+                snapshot_threshold_gb = config.snapshot_threshold_bytes / (1024 * 1024 * 1024),
+                "Iceberg mode enabled - using optimized flush settings with batched snapshots"
             );
         }
 


### PR DESCRIPTION
## Summary

- Add `snapshot_threshold_files` (default: 10) and `snapshot_threshold_bytes` (default: 1GB) to `FlusherConfig`
- Add `PendingSnapshotStats` and `pending_snapshot_stats()` method to `ColdStorage` trait
- Implement `pending_snapshot_stats()` in `IcebergStorage` to track pending files/bytes
- Update flusher to only commit snapshot when thresholds exceeded
- Force commit all pending snapshots on `flush_now` (used during shutdown)
- Add `ZOMBI_SNAPSHOT_THRESHOLD_FILES` and `ZOMBI_SNAPSHOT_THRESHOLD_GB` environment variables

## Why

This reduces S3 metadata operations by ~10x under high throughput by accumulating files across flushes and committing snapshots less frequently. This is the Mooncake pattern for efficient Iceberg ingestion.

## Test plan

- [x] All existing tests pass
- [x] Flusher config tests verify new threshold defaults
- [x] `cargo clippy` passes

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)