### PR TITLE
perf(flusher): async pipelining for S3/Iceberg flush path

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -325,6 +325,7 @@ Redis stores:
 | `ZOMBI_COMPACTED_FILE_SIZE_MB` | `512` | Target file size after compaction |
 | `ZOMBI_SNAPSHOT_THRESHOLD_FILES` | `10` | Min files before snapshot commit |
 | `ZOMBI_SNAPSHOT_THRESHOLD_GB` | `1` | Min GB before snapshot commit |
+| `ZOMBI_MAX_CONCURRENT_S3_UPLOADS` | `4` | Max concurrent S3 uploads |
 | `ZOMBI_FLUSH_INTERVAL_SECS` | `30` | Flush interval |
 | `ZOMBI_FLUSH_MIN_EVENTS` | `10000` | Min events before flush |
 | **Catalog** |

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 .and_then(|v| v.parse::<usize>().ok())
                 .map(|gb| gb * 1024 * 1024 * 1024)
                 .unwrap_or(base_config.snapshot_threshold_bytes),
+            max_concurrent_s3_uploads: std::env::var("ZOMBI_MAX_CONCURRENT_S3_UPLOADS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(base_config.max_concurrent_s3_uploads),
         };
 
         if iceberg_enabled {
@@ -121,7 +125,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 target_file_size_mb = config.target_file_size_bytes / (1024 * 1024),
                 snapshot_threshold_files = config.snapshot_threshold_files,
                 snapshot_threshold_gb = config.snapshot_threshold_bytes / (1024 * 1024 * 1024),
-                "Iceberg mode enabled - using optimized flush settings with batched snapshots"
+                max_concurrent_s3_uploads = config.max_concurrent_s3_uploads,
+                "Iceberg mode enabled - using optimized flush settings with pipelined S3 uploads"
             );
         }
 


### PR DESCRIPTION
## Summary

- Add `max_concurrent_s3_uploads` config (default: 4) to `FlusherConfig`
- Use `FuturesUnordered` to pipeline S3 uploads across partitions
- Add `ZOMBI_MAX_CONCURRENT_S3_UPLOADS` environment variable

## Why

S3 writes have high latency (50-200ms per PUT). The current flusher writes partitions sequentially. This change pipelines multiple uploads to amortize latency and improve flush throughput, especially when flushing many partitions.

## Test plan

- [x] All existing flusher tests pass
- [x] Config tests verify new default (4 concurrent uploads)
- [x] `cargo clippy` passes

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)