### PR TITLE
feat(storage): add timestamp secondary index for time-based queries

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -338,6 +338,8 @@ Redis stores:
 | **Scaling** |
 | `ZOMBI_REDIS_URL` | - | Redis URL (enables multi-node) |
 | `ZOMBI_NODE_ID` | `auto` | Unique node identifier |
+| **Optimization** |
+| `ZOMBI_TIMESTAMP_INDEX_ENABLED` | `false` | Enable timestamp secondary index |
 | **Observability** |
 | `RUST_LOG` | `zombi=info` | Log level |
 


### PR DESCRIPTION
## Summary

- Adds optional timestamp secondary index for O(log n) time-based queries
- New key format: `ts:{topic}:{partition}:{timestamp_hex}:{sequence_hex}`
- Enabled via `ZOMBI_TIMESTAMP_INDEX_ENABLED=true` environment variable
- Falls back to partition scan when index is disabled

Closes #50

## Test plan
- [x] Unit tests for timestamp index key generation and parsing
- [x] Integration tests for `read_by_timestamp` method
- [x] Verified fallback behavior when index is disabled
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)