### PR TITLE
feat: add column projection for read queries

### DIFF
--- a/src/contracts/cold_storage.rs
+++ b/src/contracts/cold_storage.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use serde::Serialize;
 
 use crate::contracts::error::StorageError;
+use crate::contracts::storage::ColumnProjection;
 use crate::contracts::StoredEvent;
 
 /// Information about the cold storage backend.
@@ -42,6 +43,7 @@ pub trait ColdStorage: Send + Sync {
 
     /// Reads events from cold storage starting at the given offset.
     /// Optional time range parameters enable partition pruning for better performance.
+    #[allow(clippy::too_many_arguments)]
     fn read_events(
         &self,
         topic: &str,
@@ -50,6 +52,7 @@ pub trait ColdStorage: Send + Sync {
         limit: usize,
         since_ms: Option<i64>,
         until_ms: Option<i64>,
+        projection: &ColumnProjection,
     ) -> impl Future<Output = Result<Vec<StoredEvent>, StorageError>> + Send;
 
     /// Lists all segments for a topic/partition.

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -10,4 +10,4 @@ pub use error::{LockResultExt, SequenceError, StorageError, ZombiError};
 pub use flusher::{FlushResult, Flusher};
 pub use schema::{ExtractedField, FieldType, PayloadFormat, TableSchemaConfig};
 pub use sequence::SequenceGenerator;
-pub use storage::{BulkWriteEvent, HotStorage, StoredEvent};
+pub use storage::{BulkWriteEvent, ColumnProjection, HotStorage, StoredEvent, KNOWN_COLUMNS};

--- a/src/flusher/mod.rs
+++ b/src/flusher/mod.rs
@@ -812,6 +812,7 @@ mod tests {
             _limit: usize,
             _since_ms: Option<i64>,
             _until_ms: Option<i64>,
+            _projection: &crate::contracts::ColumnProjection,
         ) -> Result<Vec<StoredEvent>, StorageError> {
             Ok(Vec::new())
         }

--- a/src/storage/cold_storage_backend.rs
+++ b/src/storage/cold_storage_backend.rs
@@ -1,6 +1,8 @@
 //! Unified cold storage backend that supports both S3 and Iceberg modes.
 
-use crate::contracts::{ColdStorage, ColdStorageInfo, SegmentInfo, StorageError, StoredEvent};
+use crate::contracts::{
+    ColdStorage, ColdStorageInfo, ColumnProjection, SegmentInfo, StorageError, StoredEvent,
+};
 use crate::storage::{IcebergStorage, S3Storage};
 
 /// Unified cold storage backend supporting multiple storage modes.
@@ -49,15 +51,32 @@ impl ColdStorage for ColdStorageBackend {
         limit: usize,
         since_ms: Option<i64>,
         until_ms: Option<i64>,
+        projection: &ColumnProjection,
     ) -> Result<Vec<StoredEvent>, StorageError> {
         match self {
             Self::S3(s) => {
-                s.read_events(topic, partition, start_offset, limit, since_ms, until_ms)
-                    .await
+                s.read_events(
+                    topic,
+                    partition,
+                    start_offset,
+                    limit,
+                    since_ms,
+                    until_ms,
+                    projection,
+                )
+                .await
             }
             Self::Iceberg(s) => {
-                s.read_events(topic, partition, start_offset, limit, since_ms, until_ms)
-                    .await
+                s.read_events(
+                    topic,
+                    partition,
+                    start_offset,
+                    limit,
+                    since_ms,
+                    until_ms,
+                    projection,
+                )
+                .await
             }
         }
     }

--- a/src/storage/iceberg_storage.rs
+++ b/src/storage/iceberg_storage.rs
@@ -392,6 +392,7 @@ impl ColdStorage for IcebergStorage {
         limit: usize,
         since_ms: Option<i64>,
         until_ms: Option<i64>,
+        _projection: &crate::contracts::ColumnProjection,
     ) -> Result<Vec<StoredEvent>, StorageError> {
         // Log warning if time range not provided (less efficient)
         if since_ms.is_none() || until_ms.is_none() {

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -191,6 +191,7 @@ impl ColdStorage for S3Storage {
         limit: usize,
         _since_ms: Option<i64>,
         _until_ms: Option<i64>,
+        _projection: &crate::contracts::ColumnProjection,
     ) -> Result<Vec<StoredEvent>, StorageError> {
         // List segments that might contain our offset
         let segments = self.list_segments(topic, partition).await?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,7 +7,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tempfile::TempDir;
-use zombi::contracts::{ColdStorage, ColdStorageInfo, SegmentInfo, StorageError, StoredEvent};
+use zombi::contracts::{
+    ColdStorage, ColdStorageInfo, ColumnProjection, SegmentInfo, StorageError, StoredEvent,
+};
 use zombi::storage::RocksDbStorage;
 
 // =============================================================================
@@ -101,6 +103,7 @@ impl ColdStorage for FileColdStorage {
         limit: usize,
         _since_ms: Option<i64>,
         _until_ms: Option<i64>,
+        _projection: &ColumnProjection,
     ) -> Result<Vec<StoredEvent>, StorageError> {
         let dir = self.segment_dir(topic, partition);
         if !dir.exists() {

--- a/tests/crash_recovery_tests.rs
+++ b/tests/crash_recovery_tests.rs
@@ -631,6 +631,7 @@ impl ColdStorage for FileColdStorage {
         limit: usize,
         _since_ms: Option<i64>,
         _until_ms: Option<i64>,
+        _projection: &zombi::contracts::ColumnProjection,
     ) -> Result<Vec<StoredEvent>, zombi::contracts::StorageError> {
         let dir = self.segment_dir(topic, partition);
         if !dir.exists() {
@@ -840,7 +841,15 @@ async fn flushed_events_readable_after_restart() {
     {
         let cold_storage = FileColdStorage::new(cold_dir.path());
         let events = cold_storage
-            .read_events("test-topic", 0, 0, 1000, None, None)
+            .read_events(
+                "test-topic",
+                0,
+                0,
+                1000,
+                None,
+                None,
+                &zombi::contracts::ColumnProjection::all(),
+            )
             .await
             .expect("read should succeed");
 
@@ -938,7 +947,15 @@ async fn mixed_hot_cold_recovery() {
 
         // Cold storage should have only the first batch
         let cold_events = cold_storage
-            .read_events("test-topic", 0, 0, 1000, None, None)
+            .read_events(
+                "test-topic",
+                0,
+                0,
+                1000,
+                None,
+                None,
+                &zombi::contracts::ColumnProjection::all(),
+            )
             .await
             .expect("cold read should succeed");
         assert_eq!(


### PR DESCRIPTION
## Summary
- Add `fields` query parameter to `GET /tables/{table}` endpoint for column projection
- Only requested fields are included in the response, reducing payload size
- Thread `ColumnProjection` type through `ColdStorage` trait for future Parquet-level I/O optimization

## Changes
- **`src/contracts/storage.rs`** — Add `ColumnProjection` enum and `KNOWN_COLUMNS` constant
- **`src/api/handlers.rs`** — Parse `fields` query param, validate against known columns, filter response
- **`src/contracts/cold_storage.rs`** / **`src/storage/cold_storage_backend.rs`** — Thread projection through `ColdStorage::read_events`
- **`tests/integration_tests.rs`** — 5 new tests covering field selection, validation, and defaults

## Test plan
- [x] All 192 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual smoke test with `?fields=offset,timestamp` query param

🤖 Generated with [Claude Code](https://claude.com/claude-code)