### PR TITLE
feat: implement read-only Iceberg REST catalog API

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -526,10 +526,12 @@ GET /consumers/{group}/offset?topic=events&partition=0
 For query-engine discovery, Zombi exposes a read-only subset of the Iceberg REST Catalog API:
 
 ```http
-GET /v1/config
-GET /v1/namespaces
-GET /v1/namespaces/{namespace}/tables
-GET /v1/namespaces/{namespace}/tables/{table}
+GET  /v1/config
+GET  /v1/namespaces
+GET  /v1/namespaces/{namespace}
+GET  /v1/namespaces/{namespace}/tables
+GET  /v1/namespaces/{namespace}/tables/{table}
+HEAD /v1/namespaces/{namespace}/tables/{table}
 ```
 
 These routes are isolated from `/tables/*` ingestion/read routes and return Iceberg-compatible

--- a/SPEC.md
+++ b/SPEC.md
@@ -336,7 +336,7 @@ s3://bucket/tables/{topic}/
 |---------|--------|----------|
 | Filesystem | ✅ Implemented | Development, simple deployments |
 | REST Catalog (client registration) | ✅ Implemented | Auto-register tables in external catalogs |
-| REST Catalog API (server) | Planned | Engine discovery via Zombi |
+| REST Catalog API (server, read-only) | ✅ Implemented | Engine discovery via Zombi (`/v1/config`, namespaces, tables, load-table) |
 | Hive Metastore | Planned | Legacy Hadoop environments |
 
 ### Query Engine Compatibility
@@ -520,7 +520,20 @@ GET /consumers/{group}/offset?topic=events&partition=0
 
 - **Arrow IPC response format** — `Accept: application/vnd.apache.arrow.stream` on `GET /tables/{table}` for plugin reads
 - **Watermark boundary** — per-partition committed flush watermark
-- **Iceberg REST Catalog API** — standards-compliant catalog endpoints for engine discovery
+
+### Iceberg REST Catalog API (Read-Only)
+
+For query-engine discovery, Zombi exposes a read-only subset of the Iceberg REST Catalog API:
+
+```http
+GET /v1/config
+GET /v1/namespaces
+GET /v1/namespaces/{namespace}/tables
+GET /v1/namespaces/{namespace}/tables/{table}
+```
+
+These routes are isolated from `/tables/*` ingestion/read routes and return Iceberg-compatible
+catalog responses, including the current `s3://.../metadata/v{N}.metadata.json` location on load-table.
 
 ### Admin APIs
 

--- a/src/api/catalog.rs
+++ b/src/api/catalog.rs
@@ -1,0 +1,389 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::api::handlers::{validate_table_name, AppState};
+use crate::contracts::{ColdStorage, HotStorage};
+
+const DEFAULT_NAMESPACE: &str = "zombi";
+const NAMESPACE_SEPARATOR: char = '\u{1F}';
+
+#[derive(Debug, Serialize)]
+pub struct CatalogConfigResponse {
+    pub defaults: HashMap<String, String>,
+    pub overrides: HashMap<String, String>,
+    pub endpoints: Vec<String>,
+    #[serde(
+        rename = "idempotency-key-lifetime",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub idempotency_key_lifetime: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListNamespacesQuery {
+    pub parent: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListNamespacesResponse {
+    #[serde(rename = "next-page-token", skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+    pub namespaces: Vec<Vec<String>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LoadNamespaceResponse {
+    pub namespace: Vec<String>,
+    pub properties: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListTablesResponse {
+    #[serde(rename = "next-page-token", skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+    pub identifiers: Vec<TableIdentifier>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TableIdentifier {
+    pub namespace: Vec<String>,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LoadTableResponse {
+    #[serde(rename = "metadata-location")]
+    pub metadata_location: String,
+    pub metadata: serde_json::Value,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub config: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IcebergErrorResponse {
+    pub error: IcebergErrorModel,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IcebergErrorModel {
+    pub message: String,
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub code: u16,
+}
+
+type CatalogError = (StatusCode, Json<IcebergErrorResponse>);
+
+fn parse_namespace_path(raw: &str) -> Vec<String> {
+    raw.split(NAMESPACE_SEPARATOR)
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| segment.to_string())
+        .collect()
+}
+
+fn parse_namespace_config(raw: &str) -> Vec<String> {
+    if raw.contains(NAMESPACE_SEPARATOR) {
+        return parse_namespace_path(raw);
+    }
+
+    raw.split('.')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| segment.to_string())
+        .collect()
+}
+
+fn configured_namespace() -> Vec<String> {
+    let raw = std::env::var("ZOMBI_CATALOG_NAMESPACE").unwrap_or_else(|_| DEFAULT_NAMESPACE.into());
+    let parsed = parse_namespace_config(&raw);
+    if parsed.is_empty() {
+        vec![DEFAULT_NAMESPACE.into()]
+    } else {
+        parsed
+    }
+}
+
+fn iceberg_error(
+    status: StatusCode,
+    error_type: &'static str,
+    message: impl Into<String>,
+) -> CatalogError {
+    (
+        status,
+        Json(IcebergErrorResponse {
+            error: IcebergErrorModel {
+                message: message.into(),
+                error_type: error_type.into(),
+                code: status.as_u16(),
+            },
+        }),
+    )
+}
+
+fn no_such_namespace(raw_namespace: &str) -> CatalogError {
+    iceberg_error(
+        StatusCode::NOT_FOUND,
+        "NoSuchNamespaceException",
+        format!("Namespace does not exist: {}", raw_namespace),
+    )
+}
+
+fn no_such_table(namespace: &str, table: &str) -> CatalogError {
+    iceberg_error(
+        StatusCode::NOT_FOUND,
+        "NoSuchTableException",
+        format!("Table does not exist: {}.{}", namespace, table),
+    )
+}
+
+fn internal_error(message: impl Into<String>) -> CatalogError {
+    iceberg_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "RESTException",
+        message.into(),
+    )
+}
+
+fn validate_exact_namespace(path_namespace: &str, expected: &[String]) -> Result<(), CatalogError> {
+    let actual = parse_namespace_path(path_namespace);
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(no_such_namespace(path_namespace))
+    }
+}
+
+fn list_namespaces_for_parent(
+    expected: &[String],
+    parent: Option<&str>,
+) -> Result<Vec<Vec<String>>, CatalogError> {
+    if expected.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let top_level = vec![expected[0].clone()];
+    let Some(raw_parent) = parent.filter(|raw| !raw.is_empty()) else {
+        return Ok(vec![top_level]);
+    };
+
+    let parent_parts = parse_namespace_path(raw_parent);
+    if parent_parts.is_empty() {
+        return Ok(vec![top_level]);
+    }
+    if parent_parts.len() > expected.len() || !expected.starts_with(&parent_parts) {
+        return Err(no_such_namespace(raw_parent));
+    }
+    if parent_parts.len() == expected.len() {
+        return Ok(Vec::new());
+    }
+
+    Ok(vec![expected[..(parent_parts.len() + 1)].to_vec()])
+}
+
+/// GET /v1/config
+pub async fn get_catalog_config<H: HotStorage, C: ColdStorage>(
+    State(state): State<Arc<AppState<H, C>>>,
+) -> Json<CatalogConfigResponse> {
+    let mut overrides = HashMap::new();
+    if let Some(cold) = &state.cold_storage {
+        let info = cold.storage_info();
+        if info.iceberg_enabled && !info.bucket.is_empty() && !info.base_path.is_empty() {
+            overrides.insert(
+                "warehouse".into(),
+                format!(
+                    "s3://{}/{}",
+                    info.bucket,
+                    info.base_path.trim_end_matches('/')
+                ),
+            );
+        }
+    }
+    overrides.insert("namespace-separator".into(), "%1F".into());
+
+    Json(CatalogConfigResponse {
+        defaults: HashMap::new(),
+        overrides,
+        endpoints: vec![
+            "GET /v1/config".into(),
+            "GET /v1/{prefix}/namespaces".into(),
+            "GET /v1/{prefix}/namespaces/{namespace}".into(),
+            "GET /v1/{prefix}/namespaces/{namespace}/tables".into(),
+            "GET /v1/{prefix}/namespaces/{namespace}/tables/{table}".into(),
+            "HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}".into(),
+        ],
+        idempotency_key_lifetime: None,
+    })
+}
+
+/// GET /v1/namespaces
+pub async fn list_namespaces(
+    Query(query): Query<ListNamespacesQuery>,
+) -> Result<Json<ListNamespacesResponse>, CatalogError> {
+    let expected = configured_namespace();
+    let namespaces = list_namespaces_for_parent(&expected, query.parent.as_deref())?;
+    Ok(Json(ListNamespacesResponse {
+        next_page_token: None,
+        namespaces,
+    }))
+}
+
+/// GET /v1/namespaces/{namespace}
+pub async fn load_namespace(
+    Path(namespace): Path<String>,
+) -> Result<Json<LoadNamespaceResponse>, CatalogError> {
+    let expected = configured_namespace();
+    validate_exact_namespace(&namespace, &expected)?;
+    Ok(Json(LoadNamespaceResponse {
+        namespace: expected,
+        properties: HashMap::new(),
+    }))
+}
+
+/// GET /v1/namespaces/{namespace}/tables
+pub async fn list_tables<H: HotStorage, C: ColdStorage>(
+    State(state): State<Arc<AppState<H, C>>>,
+    Path(namespace): Path<String>,
+) -> Result<Json<ListTablesResponse>, CatalogError> {
+    let expected_namespace = configured_namespace();
+    validate_exact_namespace(&namespace, &expected_namespace)?;
+
+    let Some(cold) = &state.cold_storage else {
+        return Ok(Json(ListTablesResponse {
+            next_page_token: None,
+            identifiers: Vec::new(),
+        }));
+    };
+
+    if !cold.storage_info().iceberg_enabled {
+        return Ok(Json(ListTablesResponse {
+            next_page_token: None,
+            identifiers: Vec::new(),
+        }));
+    }
+
+    let mut table_names = cold
+        .list_iceberg_tables()
+        .await
+        .map_err(|e| internal_error(format!("Failed to list Iceberg tables: {}", e)))?;
+
+    table_names.retain(|name| validate_table_name(name).is_ok());
+    table_names.sort();
+    table_names.dedup();
+
+    let identifiers = table_names
+        .into_iter()
+        .map(|name| TableIdentifier {
+            namespace: expected_namespace.clone(),
+            name,
+        })
+        .collect();
+
+    Ok(Json(ListTablesResponse {
+        next_page_token: None,
+        identifiers,
+    }))
+}
+
+/// GET /v1/namespaces/{namespace}/tables/{table}
+pub async fn load_table<H: HotStorage, C: ColdStorage>(
+    State(state): State<Arc<AppState<H, C>>>,
+    Path((namespace, table)): Path<(String, String)>,
+) -> Result<Json<LoadTableResponse>, CatalogError> {
+    let expected_namespace = configured_namespace();
+    validate_exact_namespace(&namespace, &expected_namespace)?;
+
+    if validate_table_name(&table).is_err() {
+        return Err(no_such_table(&namespace, &table));
+    }
+
+    let Some(cold) = &state.cold_storage else {
+        return Err(no_such_table(&namespace, &table));
+    };
+    if !cold.storage_info().iceberg_enabled {
+        return Err(no_such_table(&namespace, &table));
+    }
+
+    let loaded = cold
+        .load_iceberg_table(&table)
+        .await
+        .map_err(|e| internal_error(format!("Failed to load table metadata: {}", e)))?;
+    let Some(loaded) = loaded else {
+        return Err(no_such_table(&namespace, &table));
+    };
+
+    let metadata: serde_json::Value = serde_json::from_str(&loaded.metadata_json)
+        .map_err(|e| internal_error(format!("Invalid table metadata JSON: {}", e)))?;
+
+    Ok(Json(LoadTableResponse {
+        metadata_location: loaded.metadata_location,
+        metadata,
+        config: HashMap::new(),
+    }))
+}
+
+/// HEAD /v1/namespaces/{namespace}/tables/{table}
+pub async fn table_exists<H: HotStorage, C: ColdStorage>(
+    State(state): State<Arc<AppState<H, C>>>,
+    Path((namespace, table)): Path<(String, String)>,
+) -> Result<StatusCode, CatalogError> {
+    let expected_namespace = configured_namespace();
+    validate_exact_namespace(&namespace, &expected_namespace)?;
+
+    if validate_table_name(&table).is_err() {
+        return Err(no_such_table(&namespace, &table));
+    }
+
+    let Some(cold) = &state.cold_storage else {
+        return Err(no_such_table(&namespace, &table));
+    };
+    if !cold.storage_info().iceberg_enabled {
+        return Err(no_such_table(&namespace, &table));
+    }
+
+    let exists = cold
+        .load_iceberg_table(&table)
+        .await
+        .map_err(|e| internal_error(format!("Failed to check table existence: {}", e)))?
+        .is_some();
+
+    if exists {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(no_such_table(&namespace, &table))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namespace_path_parsing_uses_unit_separator_only() {
+        assert_eq!(
+            parse_namespace_path("accounting\u{1F}tax"),
+            vec!["accounting".to_string(), "tax".to_string()]
+        );
+        assert_eq!(
+            parse_namespace_path("accounting.tax"),
+            vec!["accounting.tax".to_string()]
+        );
+    }
+
+    #[test]
+    fn namespace_config_parsing_accepts_dot_for_env_compatibility() {
+        assert_eq!(
+            parse_namespace_config("accounting.tax"),
+            vec!["accounting".to_string(), "tax".to_string()]
+        );
+        assert_eq!(
+            parse_namespace_config("accounting\u{1F}tax"),
+            vec!["accounting".to_string(), "tax".to_string()]
+        );
+    }
+}

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -119,6 +119,8 @@ pub struct AppState<H: HotStorage, C: ColdStorage = NoopColdStorage> {
     pub max_inflight_bytes: u64,
     /// Optional write combiner for batching single writes
     pub write_combiner: Option<Arc<WriteCombiner<H>>>,
+    /// Catalog namespace, computed once at startup from ZOMBI_CATALOG_NAMESPACE.
+    pub catalog_namespace: Vec<String>,
 }
 
 impl<H: HotStorage, C: ColdStorage> AppState<H, C> {
@@ -129,6 +131,7 @@ impl<H: HotStorage, C: ColdStorage> AppState<H, C> {
         metrics: Arc<Metrics>,
         metrics_registry: Arc<MetricsRegistry>,
         backpressure: BackpressureConfig,
+        catalog_namespace: Vec<String>,
     ) -> Self {
         Self {
             storage,
@@ -139,6 +142,7 @@ impl<H: HotStorage, C: ColdStorage> AppState<H, C> {
             inflight_bytes: AtomicU64::new(0),
             max_inflight_bytes: backpressure.max_inflight_bytes as u64,
             write_combiner: None,
+            catalog_namespace,
         }
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,6 +9,7 @@ use axum::Router;
 
 use crate::contracts::{ColdStorage, HotStorage};
 
+pub use catalog::compute_catalog_namespace;
 pub use handlers::{
     AppState, BackpressureConfig, Metrics, NoopColdStorage, WriteRecordRequest, WriteRecordResponse,
 };
@@ -20,8 +21,11 @@ pub fn create_router<H: HotStorage + 'static, C: ColdStorage + 'static>(
     Router::new()
         // Iceberg REST Catalog API (read-only)
         .route("/v1/config", get(catalog::get_catalog_config::<H, C>))
-        .route("/v1/namespaces", get(catalog::list_namespaces))
-        .route("/v1/namespaces/:namespace", get(catalog::load_namespace))
+        .route("/v1/namespaces", get(catalog::list_namespaces::<H, C>))
+        .route(
+            "/v1/namespaces/:namespace",
+            get(catalog::load_namespace::<H, C>),
+        )
         .route(
             "/v1/namespaces/:namespace/tables",
             get(catalog::list_tables::<H, C>),

--- a/src/contracts/cold_storage.rs
+++ b/src/contracts/cold_storage.rs
@@ -20,6 +20,15 @@ pub struct ColdStorageInfo {
     pub base_path: String,
 }
 
+/// Committed Iceberg table details used by the REST catalog API.
+#[derive(Debug, Clone)]
+pub struct IcebergCatalogTable {
+    /// Full metadata file location (e.g. s3://bucket/path/table/metadata/v3.metadata.json).
+    pub metadata_location: String,
+    /// Iceberg table metadata JSON payload.
+    pub metadata_json: String,
+}
+
 /// Statistics about pending files for a topic, awaiting snapshot commit.
 #[derive(Debug, Clone, Default)]
 pub struct PendingSnapshotStats {
@@ -102,6 +111,21 @@ pub trait ColdStorage: Send + Sync {
     /// Only Iceberg backends return Some; S3 backends return None.
     fn table_metadata_json(&self, _topic: &str) -> Option<String> {
         None
+    }
+
+    /// Lists committed table names visible to the local Iceberg catalog.
+    fn list_iceberg_tables(
+        &self,
+    ) -> impl Future<Output = Result<Vec<String>, StorageError>> + Send {
+        async move { Ok(Vec::new()) }
+    }
+
+    /// Loads committed Iceberg table metadata for catalog responses.
+    fn load_iceberg_table(
+        &self,
+        _topic: &str,
+    ) -> impl Future<Output = Result<Option<IcebergCatalogTable>, StorageError>> + Send {
+        async move { Ok(None) }
     }
 
     /// Clears pending (uncommitted) data files for a topic/partition.

--- a/src/contracts/cold_storage.rs
+++ b/src/contracts/cold_storage.rs
@@ -128,6 +128,15 @@ pub trait ColdStorage: Send + Sync {
         async move { Ok(None) }
     }
 
+    /// Checks whether an Iceberg table exists without loading its full metadata.
+    /// Efficient backends override this to avoid downloading full metadata JSON.
+    fn iceberg_table_exists(
+        &self,
+        _topic: &str,
+    ) -> impl Future<Output = Result<bool, StorageError>> + Send {
+        async move { Ok(false) }
+    }
+
     /// Clears pending (uncommitted) data files for a topic/partition.
     ///
     /// Called when a flush partition fails partway through writing hour-group

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -5,7 +5,9 @@ pub mod schema;
 pub mod sequence;
 pub mod storage;
 
-pub use cold_storage::{ColdStorage, ColdStorageInfo, PendingSnapshotStats, SegmentInfo};
+pub use cold_storage::{
+    ColdStorage, ColdStorageInfo, IcebergCatalogTable, PendingSnapshotStats, SegmentInfo,
+};
 pub use error::{LockResultExt, SequenceError, StorageError, ZombiError};
 pub use flusher::{FlushResult, Flusher};
 pub use schema::{ExtractedField, FieldType, PayloadFormat, TableSchemaConfig};

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         None
     };
 
+    let catalog_namespace = zombi::api::compute_catalog_namespace();
     let state = Arc::new(
         AppState::new(
             storage,
@@ -248,6 +249,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             Arc::new(Metrics::new()),
             Arc::clone(&metrics_registry),
             backpressure_config,
+            catalog_namespace,
         )
         .with_write_combiner(write_combiner),
     );

--- a/src/storage/cold_storage_backend.rs
+++ b/src/storage/cold_storage_backend.rs
@@ -1,8 +1,8 @@
 //! Unified cold storage backend that supports both S3 and Iceberg modes.
 
 use crate::contracts::{
-    ColdStorage, ColdStorageInfo, ColumnProjection, PendingSnapshotStats, SegmentInfo,
-    StorageError, StoredEvent,
+    ColdStorage, ColdStorageInfo, ColumnProjection, IcebergCatalogTable, PendingSnapshotStats,
+    SegmentInfo, StorageError, StoredEvent,
 };
 use crate::storage::{IcebergStorage, S3Storage};
 
@@ -129,6 +129,23 @@ impl ColdStorage for ColdStorageBackend {
         match self {
             Self::S3(_) => None,
             Self::Iceberg(s) => s.table_metadata_json(topic),
+        }
+    }
+
+    async fn list_iceberg_tables(&self) -> Result<Vec<String>, StorageError> {
+        match self {
+            Self::S3(_) => Ok(Vec::new()),
+            Self::Iceberg(s) => s.list_tables().await,
+        }
+    }
+
+    async fn load_iceberg_table(
+        &self,
+        topic: &str,
+    ) -> Result<Option<IcebergCatalogTable>, StorageError> {
+        match self {
+            Self::S3(_) => Ok(None),
+            Self::Iceberg(s) => s.load_table_for_catalog(topic).await,
         }
     }
 

--- a/src/storage/cold_storage_backend.rs
+++ b/src/storage/cold_storage_backend.rs
@@ -149,6 +149,13 @@ impl ColdStorage for ColdStorageBackend {
         }
     }
 
+    async fn iceberg_table_exists(&self, topic: &str) -> Result<bool, StorageError> {
+        match self {
+            Self::S3(_) => Ok(false),
+            Self::Iceberg(s) => s.iceberg_table_exists(topic).await,
+        }
+    }
+
     fn pending_snapshot_stats(&self, topic: &str) -> PendingSnapshotStats {
         match self {
             Self::S3(s) => s.pending_snapshot_stats(topic),

--- a/src/storage/iceberg.rs
+++ b/src/storage/iceberg.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 
 use apache_avro::types::{Record, Value as AvroValue};
 use apache_avro::{Schema as AvroSchema, Writer as AvroWriter};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
 use crate::contracts::{StorageError, TableSchemaConfig};
@@ -419,6 +419,29 @@ impl SnapshotOperation {
     }
 }
 
+/// Serializes `Option<i64>` as `-1` for `None` (Iceberg v2 convention).
+fn serialize_snapshot_id<S: Serializer>(
+    value: &Option<i64>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        Some(id) => serializer.serialize_i64(*id),
+        None => serializer.serialize_i64(-1),
+    }
+}
+
+/// Deserializes `Option<i64>` treating negative values as `None` (Iceberg v2 convention).
+fn deserialize_snapshot_id<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<i64>, D::Error> {
+    let v = i64::deserialize(deserializer)?;
+    if v < 0 {
+        Ok(None)
+    } else {
+        Ok(Some(v))
+    }
+}
+
 /// Iceberg table metadata (v2 format).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TableMetadata {
@@ -445,7 +468,8 @@ pub struct TableMetadata {
     pub properties: HashMap<String, String>,
     #[serde(
         rename = "current-snapshot-id",
-        skip_serializing_if = "Option::is_none"
+        serialize_with = "serialize_snapshot_id",
+        deserialize_with = "deserialize_snapshot_id"
     )]
     pub current_snapshot_id: Option<i64>,
     #[serde(default)]
@@ -1133,6 +1157,33 @@ mod tests {
 
         assert_eq!(parsed.table_uuid, metadata.table_uuid);
         assert_eq!(parsed.location, metadata.location);
+    }
+
+    #[test]
+    fn test_current_snapshot_id_serializes_as_minus_one_when_none() {
+        let metadata = TableMetadata::new("s3://bucket/tables/events");
+        assert!(metadata.current_snapshot_id.is_none());
+
+        let json = metadata.to_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["current-snapshot-id"], -1);
+
+        // Round-trip: -1 deserializes back to None
+        let round_tripped = TableMetadata::from_json(&json).unwrap();
+        assert!(round_tripped.current_snapshot_id.is_none());
+    }
+
+    #[test]
+    fn test_current_snapshot_id_serializes_positive_value() {
+        let mut metadata = TableMetadata::new("s3://bucket/tables/events");
+        metadata.current_snapshot_id = Some(42);
+
+        let json = metadata.to_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["current-snapshot-id"], 42);
+
+        let round_tripped = TableMetadata::from_json(&json).unwrap();
+        assert_eq!(round_tripped.current_snapshot_id, Some(42));
     }
 
     #[test]

--- a/src/storage/iceberg_storage.rs
+++ b/src/storage/iceberg_storage.rs
@@ -540,18 +540,16 @@ impl IcebergStorage {
         let mut table_names = HashSet::new();
 
         for key in keys {
-            if Self::parse_metadata_version_from_key(&key).is_none() {
-                continue;
-            }
-
             let Some(suffix) = key.strip_prefix(&root_prefix) else {
                 continue;
             };
             let Some((table, rest)) = suffix.split_once('/') else {
                 continue;
             };
-
             if table.is_empty() || !rest.starts_with("metadata/") {
+                continue;
+            }
+            if Self::parse_metadata_version_from_key(&key).is_none() {
                 continue;
             }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -159,6 +159,10 @@ impl ColdStorage for CatalogColdStorageMock {
     ) -> Result<Option<IcebergCatalogTable>, StorageError> {
         Ok(self.tables.get(topic).cloned())
     }
+
+    async fn iceberg_table_exists(&self, topic: &str) -> Result<bool, StorageError> {
+        Ok(self.tables.contains_key(topic))
+    }
 }
 
 fn create_test_app_with_backpressure(
@@ -172,6 +176,7 @@ fn create_test_app_with_backpressure(
         Arc::new(Metrics::new()),
         Arc::new(MetricsRegistry::new()),
         config,
+        vec!["zombi".into()],
     ));
     let router = create_router(state);
     (router, dir)
@@ -186,6 +191,7 @@ fn create_test_app() -> (axum::Router, tempfile::TempDir) {
         Arc::new(Metrics::new()),
         Arc::new(MetricsRegistry::new()),
         BackpressureConfig::default(),
+        vec!["zombi".into()],
     ));
     let router = create_router(state);
     (router, dir)
@@ -207,6 +213,7 @@ fn create_test_app_with_combiner(config: WriteCombinerConfig) -> (axum::Router, 
             Arc::new(Metrics::new()),
             metrics_registry,
             BackpressureConfig::default(),
+            vec!["zombi".into()],
         )
         .with_write_combiner(Some(combiner)),
     );
@@ -223,6 +230,7 @@ fn create_test_app_with_cold_storage() -> (axum::Router, tempfile::TempDir) {
         Arc::new(Metrics::new()),
         Arc::new(MetricsRegistry::new()),
         BackpressureConfig::default(),
+        vec!["zombi".into()],
     ));
     let router = create_router(state);
     (router, dir)
@@ -237,6 +245,7 @@ fn create_test_app_with_panic_cold_storage() -> (axum::Router, tempfile::TempDir
         Arc::new(Metrics::new()),
         Arc::new(MetricsRegistry::new()),
         BackpressureConfig::default(),
+        vec!["zombi".into()],
     ));
     let router = create_router(state);
     (router, dir)
@@ -251,6 +260,7 @@ fn create_test_app_with_catalog_storage() -> (axum::Router, tempfile::TempDir) {
         Arc::new(Metrics::new()),
         Arc::new(MetricsRegistry::new()),
         BackpressureConfig::default(),
+        vec!["zombi".into()],
     ));
     let router = create_router(state);
     (router, dir)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -7,7 +8,7 @@ use prost::Message;
 use tower::ServiceExt;
 
 use zombi::api::{create_router, AppState, BackpressureConfig, Metrics, NoopColdStorage};
-use zombi::contracts::{ColdStorage, StorageError};
+use zombi::contracts::{ColdStorage, IcebergCatalogTable, StorageError};
 use zombi::metrics::MetricsRegistry;
 use zombi::proto;
 use zombi::storage::{RocksDbStorage, WriteCombiner, WriteCombinerConfig};
@@ -54,6 +55,109 @@ impl ColdStorage for PanicOnReadColdStorage {
             bucket: String::new(),
             base_path: String::new(),
         }
+    }
+}
+
+/// Iceberg catalog mock used by /v1 REST catalog integration tests.
+struct CatalogColdStorageMock {
+    tables: HashMap<String, IcebergCatalogTable>,
+}
+
+impl CatalogColdStorageMock {
+    fn new() -> Self {
+        let mut tables = HashMap::new();
+        tables.insert(
+            "events".into(),
+            IcebergCatalogTable {
+                metadata_location: "s3://test-bucket/tables/events/metadata/v7.metadata.json"
+                    .into(),
+                metadata_json: serde_json::json!({
+                    "format-version": 2,
+                    "table-uuid": "4f5f45df-fa40-4f44-b95d-f3ae6f2f68d0",
+                    "location": "s3://test-bucket/tables/events",
+                    "last-sequence-number": 7,
+                    "last-updated-ms": 1700000000000_i64,
+                    "last-column-id": 8,
+                    "schemas": [{
+                        "type": "struct",
+                        "schema-id": 0,
+                        "fields": []
+                    }],
+                    "current-schema-id": 0,
+                    "partition-specs": [{
+                        "spec-id": 0,
+                        "fields": []
+                    }],
+                    "default-spec-id": 0,
+                    "last-partition-id": 999,
+                    "properties": {},
+                    "current-snapshot-id": serde_json::Value::Null,
+                    "snapshots": [],
+                    "snapshot-log": [],
+                    "sort-orders": [{
+                        "order-id": 0,
+                        "fields": []
+                    }],
+                    "default-sort-order-id": 0
+                })
+                .to_string(),
+            },
+        );
+        Self { tables }
+    }
+}
+
+impl ColdStorage for CatalogColdStorageMock {
+    async fn write_segment(
+        &self,
+        _topic: &str,
+        _partition: u32,
+        _events: &[zombi::contracts::StoredEvent],
+    ) -> Result<String, StorageError> {
+        Err(StorageError::S3("not configured".into()))
+    }
+
+    async fn read_events(
+        &self,
+        _topic: &str,
+        _partition: u32,
+        _start_offset: u64,
+        _limit: usize,
+        _since_ms: Option<i64>,
+        _until_ms: Option<i64>,
+        _projection: &zombi::contracts::ColumnProjection,
+    ) -> Result<Vec<zombi::contracts::StoredEvent>, StorageError> {
+        Ok(Vec::new())
+    }
+
+    async fn list_segments(
+        &self,
+        _topic: &str,
+        _partition: u32,
+    ) -> Result<Vec<zombi::contracts::SegmentInfo>, StorageError> {
+        Ok(Vec::new())
+    }
+
+    fn storage_info(&self) -> zombi::contracts::ColdStorageInfo {
+        zombi::contracts::ColdStorageInfo {
+            storage_type: "iceberg".into(),
+            iceberg_enabled: true,
+            bucket: "test-bucket".into(),
+            base_path: "tables".into(),
+        }
+    }
+
+    async fn list_iceberg_tables(&self) -> Result<Vec<String>, StorageError> {
+        let mut names: Vec<String> = self.tables.keys().cloned().collect();
+        names.sort();
+        Ok(names)
+    }
+
+    async fn load_iceberg_table(
+        &self,
+        topic: &str,
+    ) -> Result<Option<IcebergCatalogTable>, StorageError> {
+        Ok(self.tables.get(topic).cloned())
     }
 }
 
@@ -138,6 +242,41 @@ fn create_test_app_with_panic_cold_storage() -> (axum::Router, tempfile::TempDir
     (router, dir)
 }
 
+fn create_test_app_with_catalog_storage() -> (axum::Router, tempfile::TempDir) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let storage = RocksDbStorage::open(dir.path()).unwrap();
+    let state = Arc::new(AppState::new(
+        Arc::new(storage),
+        Some(Arc::new(CatalogColdStorageMock::new())),
+        Arc::new(Metrics::new()),
+        Arc::new(MetricsRegistry::new()),
+        BackpressureConfig::default(),
+    ));
+    let router = create_router(state);
+    (router, dir)
+}
+
+fn configured_catalog_namespace() -> String {
+    std::env::var("ZOMBI_CATALOG_NAMESPACE").unwrap_or_else(|_| "zombi".into())
+}
+
+fn configured_catalog_namespace_parts() -> Vec<String> {
+    let raw = configured_catalog_namespace();
+    if raw.contains('\u{1F}') {
+        raw.split('\u{1F}')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect()
+    } else {
+        raw.split('.')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect()
+    }
+}
+
 #[tokio::test]
 async fn test_health_check() {
     let (app, _dir) = create_test_app();
@@ -153,6 +292,266 @@ async fn test_health_check() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_catalog_config_endpoint() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/config")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert!(json["defaults"].is_object());
+    assert!(json["overrides"].is_object());
+    assert_eq!(json["overrides"]["warehouse"], "s3://test-bucket/tables");
+    assert_eq!(json["overrides"]["namespace-separator"], "%1F");
+
+    let endpoints = json["endpoints"].as_array().unwrap();
+    assert!(endpoints
+        .iter()
+        .any(|v| v.as_str() == Some("GET /v1/{prefix}/namespaces")));
+    assert!(endpoints
+        .iter()
+        .any(|v| v.as_str() == Some("GET /v1/{prefix}/namespaces/{namespace}")));
+    assert!(endpoints
+        .iter()
+        .any(|v| v.as_str() == Some("GET /v1/{prefix}/namespaces/{namespace}/tables/{table}")));
+    assert!(endpoints.iter().any(|v| {
+        v.as_str() == Some("HEAD /v1/{prefix}/namespaces/{namespace}/tables/{table}")
+    }));
+}
+
+#[tokio::test]
+async fn test_catalog_list_namespaces() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+    let expected = configured_catalog_namespace();
+    let expected_top = expected.split('.').next().unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/namespaces")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["namespaces"][0][0], expected_top);
+}
+
+#[tokio::test]
+async fn test_catalog_list_tables() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+    let namespace = configured_catalog_namespace();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/namespaces/{}/tables", namespace))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["identifiers"].as_array().unwrap().len(), 1);
+    assert_eq!(json["identifiers"][0]["name"], "events");
+}
+
+#[tokio::test]
+async fn test_catalog_load_table() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+    let namespace = configured_catalog_namespace();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/namespaces/{}/tables/events", namespace))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(
+        json["metadata-location"],
+        "s3://test-bucket/tables/events/metadata/v7.metadata.json"
+    );
+    assert_eq!(json["metadata"]["format-version"], 2);
+}
+
+#[tokio::test]
+async fn test_catalog_load_table_not_found() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+    let namespace = configured_catalog_namespace();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/namespaces/{}/tables/missing", namespace))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "NoSuchTableException");
+    assert_eq!(json["error"]["code"], 404);
+}
+
+#[tokio::test]
+async fn test_catalog_namespace_not_found() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/namespaces/unknown/tables")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "NoSuchNamespaceException");
+    assert_eq!(json["error"]["code"], 404);
+}
+
+#[tokio::test]
+async fn test_catalog_load_namespace() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+    let namespace = configured_catalog_namespace();
+    let namespace_parts = configured_catalog_namespace_parts();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/namespaces/{}", namespace))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["namespace"], serde_json::json!(namespace_parts));
+    assert!(json["properties"].is_object());
+}
+
+#[tokio::test]
+async fn test_catalog_load_namespace_not_found() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/namespaces/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["type"], "NoSuchNamespaceException");
+    assert_eq!(json["error"]["code"], 404);
+}
+
+#[tokio::test]
+async fn test_catalog_table_exists_head() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+    let namespace = configured_catalog_namespace();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("HEAD")
+                .uri(format!("/v1/namespaces/{}/tables/events", namespace))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn test_catalog_table_not_exists_head() {
+    let (app, _dir) = create_test_app_with_catalog_storage();
+    let namespace = configured_catalog_namespace();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("HEAD")
+                .uri(format!("/v1/namespaces/{}/tables/missing", namespace))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- implement read-only Iceberg REST catalog server endpoints under `/v1`
  - `GET /v1/config`
  - `GET /v1/namespaces`
  - `GET /v1/namespaces/{namespace}`
  - `GET /v1/namespaces/{namespace}/tables`
  - `GET /v1/namespaces/{namespace}/tables/{table}`
  - `HEAD /v1/namespaces/{namespace}/tables/{table}`
- keep `/v1` routes isolated from existing `/tables/*` API routes
- add catalog-focused cold-storage abstractions and wire them through the Iceberg backend
- return exact committed metadata file locations (`v{N}.metadata.json`) for table load
- improve namespace parsing fidelity for request paths/query params while preserving env compatibility
- avoid N+1 metadata loads in table listing by deriving committed tables from metadata keys
- add integration and unit coverage for catalog endpoints and parsing behavior
- update `SPEC.md` catalog support/status docs

## Validation
- `cargo fmt --check`
- `cargo test -- --nocapture`

Fixes #104
