### PR TITLE
feat: snapshot watermarks + max-age threshold docs (#109, #107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ See [tools/README.md](tools/README.md) for more options.
 | `ZOMBI_FLUSH_INTERVAL_SECS` | `5` | `300` | Flush interval in seconds |
 | `ZOMBI_FLUSH_BATCH_SIZE` | `1000` | `10000` | Min events before flushing |
 | `ZOMBI_TARGET_FILE_SIZE_MB` | `128` | `128` | Target Parquet file size |
+| `ZOMBI_SNAPSHOT_THRESHOLD_FILES` | `10` | `10` | Min files before snapshot commit |
+| `ZOMBI_SNAPSHOT_THRESHOLD_GB` | `1` | `1` | Min GB before snapshot commit |
+| `ZOMBI_SNAPSHOT_MAX_AGE_SECS` | `1800` | `1800` | Max seconds before forcing snapshot commit |
 | `ZOMBI_ROCKSDB_WAL_ENABLED` | `true` | `true` | Enable WAL for durability (set `false` for max throughput at risk of data loss on crash) |
 | `ZOMBI_HOT_RETENTION_SECS` | `0` | `0` | Seconds to keep flushed events in hot storage before deletion (0 = delete immediately). Best-effort during runtime; bypassed on startup/shutdown |
 | `RUST_LOG` | `zombi=info` | `zombi=info` | Log level |

--- a/SPEC.md
+++ b/SPEC.md
@@ -218,7 +218,7 @@ All integer values are stored big-endian for correct lexicographic ordering in R
 4. Background flusher splits batches by (event_date, event_hour) and target file size
 5. Writes Parquet files to S3
 6. Commits Iceberg metadata (atomic)
-7. Persists flush watermark (and records boundary in snapshot summary — planned)
+7. Persists flush watermark and records boundary in snapshot summary (`zombi.watermark.{partition}`, `zombi.high_watermark.{partition}`)
 8. Deletes hot data up to watermark (configurable retention window)
 9. Optional: Register/update with external REST catalog
 ```
@@ -674,6 +674,7 @@ and **not** required for v1 of the ingestion-gateway identity.
 | `ZOMBI_COMPACTED_FILE_SIZE_MB` | `512` | Target file size after compaction |
 | `ZOMBI_SNAPSHOT_THRESHOLD_FILES` | `10` | Min files before snapshot commit |
 | `ZOMBI_SNAPSHOT_THRESHOLD_GB` | `1` | Min GB before snapshot commit |
+| `ZOMBI_SNAPSHOT_MAX_AGE_SECS` | `1800` | Max seconds before forcing snapshot commit (ensures low-throughput tables commit). Per-table overrides not yet supported |
 | `ZOMBI_MAX_CONCURRENT_S3_UPLOADS` | `4` | Max concurrent S3 uploads |
 | `ZOMBI_FLUSH_INTERVAL_SECS` | `300` | Flush interval (Iceberg mode) |
 | `ZOMBI_FLUSH_MAX_SEGMENT` | `10000` | Max events per flush segment |

--- a/src/contracts/cold_storage.rs
+++ b/src/contracts/cold_storage.rs
@@ -29,6 +29,15 @@ pub struct PendingSnapshotStats {
     pub total_bytes: u64,
 }
 
+/// Additional context captured at snapshot commit time.
+#[derive(Debug, Clone, Default)]
+pub struct SnapshotCommitContext {
+    /// Persisted flush watermark per partition at commit time.
+    pub watermarks_by_partition: HashMap<u32, u64>,
+    /// High watermark (write head) per partition at commit time.
+    pub high_watermarks_by_partition: HashMap<u32, u64>,
+}
+
 /// Cold storage for archived events (S3).
 ///
 /// Events are written in batches as log segments.
@@ -76,6 +85,7 @@ pub trait ColdStorage: Send + Sync {
     fn commit_snapshot(
         &self,
         _topic: &str,
+        _context: SnapshotCommitContext,
     ) -> impl Future<Output = Result<Option<i64>, StorageError>> + Send {
         async move { Ok(None) }
     }

--- a/src/contracts/error.rs
+++ b/src/contracts/error.rs
@@ -49,6 +49,9 @@ pub enum StorageError {
     #[error("Invalid input: {0}")]
     InvalidInput(String),
 
+    #[error("Invariant violation: {0}")]
+    InvariantViolation(String),
+
     #[error("Topic not found: {0}")]
     TopicNotFound(String),
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -5,7 +5,9 @@ pub mod schema;
 pub mod sequence;
 pub mod storage;
 
-pub use cold_storage::{ColdStorage, ColdStorageInfo, PendingSnapshotStats, SegmentInfo};
+pub use cold_storage::{
+    ColdStorage, ColdStorageInfo, PendingSnapshotStats, SegmentInfo, SnapshotCommitContext,
+};
 pub use error::{LockResultExt, SequenceError, StorageError, ZombiError};
 pub use flusher::{FlushResult, Flusher};
 pub use schema::{ExtractedField, FieldType, PayloadFormat, TableSchemaConfig};

--- a/src/flusher/mod.rs
+++ b/src/flusher/mod.rs
@@ -3301,16 +3301,18 @@ mod tests {
             "Age-triggered commit should persist watermark"
         );
 
-        let contexts = cold.commit_contexts.lock().unwrap();
-        assert!(
-            !contexts.is_empty(),
-            "At least one commit should have been made"
-        );
+        {
+            let contexts = cold.commit_contexts.lock().unwrap();
+            assert!(
+                !contexts.is_empty(),
+                "At least one commit should have been made"
+            );
 
-        let (topic, ctx) = &contexts[0];
-        assert_eq!(topic, "events");
-        assert_eq!(ctx.watermarks_by_partition.get(&0), Some(&1));
-        assert_eq!(ctx.high_watermarks_by_partition.get(&0), Some(&1));
+            let (topic, ctx) = &contexts[0];
+            assert_eq!(topic, "events");
+            assert_eq!(ctx.watermarks_by_partition.get(&0), Some(&1));
+            assert_eq!(ctx.high_watermarks_by_partition.get(&0), Some(&1));
+        }
 
         flusher.stop().await.unwrap();
     }

--- a/src/storage/cold_storage_backend.rs
+++ b/src/storage/cold_storage_backend.rs
@@ -2,7 +2,7 @@
 
 use crate::contracts::{
     ColdStorage, ColdStorageInfo, ColumnProjection, PendingSnapshotStats, SegmentInfo,
-    StorageError, StoredEvent,
+    SnapshotCommitContext, StorageError, StoredEvent,
 };
 use crate::storage::{IcebergStorage, S3Storage};
 
@@ -118,10 +118,14 @@ impl ColdStorage for ColdStorageBackend {
         }
     }
 
-    async fn commit_snapshot(&self, topic: &str) -> Result<Option<i64>, StorageError> {
+    async fn commit_snapshot(
+        &self,
+        topic: &str,
+        context: SnapshotCommitContext,
+    ) -> Result<Option<i64>, StorageError> {
         match self {
-            Self::S3(s) => s.commit_snapshot(topic).await,
-            Self::Iceberg(s) => s.commit_snapshot(topic).await,
+            Self::S3(s) => s.commit_snapshot(topic, context).await,
+            Self::Iceberg(s) => s.commit_snapshot(topic, context).await,
         }
     }
 

--- a/src/storage/combiner.rs
+++ b/src/storage/combiner.rs
@@ -391,5 +391,6 @@ fn clone_storage_error(err: &StorageError) -> StorageError {
         StorageError::Io(msg) => StorageError::Io(msg.clone()),
         StorageError::Overloaded(msg) => StorageError::Overloaded(msg.clone()),
         StorageError::LockPoisoned(msg) => StorageError::LockPoisoned(msg.clone()),
+        StorageError::InvariantViolation(msg) => StorageError::InvariantViolation(msg.clone()),
     }
 }

--- a/src/storage/iceberg.rs
+++ b/src/storage/iceberg.rs
@@ -530,6 +530,7 @@ impl TableMetadata {
         added_files: usize,
         added_rows: i64,
         operation: SnapshotOperation,
+        extra_summary: HashMap<String, String>,
     ) -> i64 {
         let snapshot_id = generate_snapshot_id();
         let now = current_timestamp_ms();
@@ -541,6 +542,12 @@ impl TableMetadata {
         summary.insert("added-records".into(), added_rows.to_string());
         summary.insert("total-records".into(), added_rows.to_string());
         summary.insert("total-data-files".into(), added_files.to_string());
+        for (key, value) in extra_summary {
+            if !key.starts_with("zombi.") {
+                continue;
+            }
+            summary.entry(key).or_insert(value);
+        }
 
         let snapshot = Snapshot {
             snapshot_id,
@@ -1115,6 +1122,7 @@ mod tests {
             1,
             100,
             SnapshotOperation::Append,
+            HashMap::new(),
         );
 
         assert!(snapshot_id > 0);
@@ -1122,6 +1130,47 @@ mod tests {
         assert_eq!(metadata.snapshots.len(), 1);
         assert_eq!(metadata.snapshot_log.len(), 1);
         assert_eq!(metadata.last_sequence_number, 1);
+    }
+
+    #[test]
+    fn add_snapshot_merges_extra_summary_and_drops_non_zombi_keys() {
+        let mut metadata = TableMetadata::new("s3://bucket/tables/events");
+
+        let mut extra = HashMap::new();
+        extra.insert("zombi.watermark.0".to_string(), "42".to_string());
+        extra.insert("zombi.high_watermark.0".to_string(), "100".to_string());
+        extra.insert("not_zombi_key".to_string(), "should_be_dropped".to_string());
+
+        let snapshot_id = metadata.add_snapshot(
+            "s3://bucket/tables/events/metadata/snap-1.avro",
+            2,
+            50,
+            SnapshotOperation::Append,
+            extra,
+        );
+
+        let snapshot = metadata
+            .snapshots
+            .iter()
+            .find(|s| s.snapshot_id == snapshot_id)
+            .expect("snapshot should exist");
+
+        // Zombi keys are present
+        assert_eq!(snapshot.summary.get("zombi.watermark.0").unwrap(), "42");
+        assert_eq!(
+            snapshot.summary.get("zombi.high_watermark.0").unwrap(),
+            "100"
+        );
+
+        // Non-zombi key was dropped
+        assert!(!snapshot.summary.contains_key("not_zombi_key"));
+
+        // Standard Iceberg keys are intact
+        assert_eq!(snapshot.summary.get("operation").unwrap(), "append");
+        assert_eq!(snapshot.summary.get("added-data-files").unwrap(), "2");
+        assert_eq!(snapshot.summary.get("added-records").unwrap(), "50");
+        assert_eq!(snapshot.summary.get("total-records").unwrap(), "50");
+        assert_eq!(snapshot.summary.get("total-data-files").unwrap(), "2");
     }
 
     #[test]

--- a/src/storage/iceberg_storage.rs
+++ b/src/storage/iceberg_storage.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 
 use crate::contracts::{
     ColdStorage, ColdStorageInfo, LockResultExt, PayloadFormat, PendingSnapshotStats, SegmentInfo,
-    StorageError, StoredEvent, TableSchemaConfig,
+    SnapshotCommitContext, StorageError, StoredEvent, TableSchemaConfig,
 };
 use crate::s3_retry;
 use crate::storage::parquet::write_parquet_to_bytes_structured_sorted;
@@ -245,6 +245,24 @@ impl IcebergStorage {
             )));
         }
         Ok((bucket.to_string(), key.to_string()))
+    }
+
+    /// Builds additional snapshot summary entries from commit context.
+    fn snapshot_summary_from_context(context: &SnapshotCommitContext) -> HashMap<String, String> {
+        let mut summary = HashMap::new();
+        for (partition, watermark) in &context.watermarks_by_partition {
+            summary.insert(
+                format!("zombi.watermark.{}", partition),
+                watermark.to_string(),
+            );
+        }
+        for (partition, high_watermark) in &context.high_watermarks_by_partition {
+            summary.insert(
+                format!("zombi.high_watermark.{}", partition),
+                high_watermark.to_string(),
+            );
+        }
+        summary
     }
 
     /// Helper: fetches a named field from an Avro record.
@@ -551,7 +569,11 @@ impl IcebergStorage {
 
     /// Commits pending data files by creating a new snapshot.
     /// This should be called after a batch of write_segment calls.
-    pub async fn commit_snapshot(&self, topic: &str) -> Result<Option<i64>, StorageError> {
+    pub async fn commit_snapshot(
+        &self,
+        topic: &str,
+        context: SnapshotCommitContext,
+    ) -> Result<Option<i64>, StorageError> {
         // Drain pending files for this topic under a write lock. This prevents
         // races where new files are added between a read snapshot and later clear.
         // New writes after this point remain in the map for the next snapshot.
@@ -580,7 +602,9 @@ impl IcebergStorage {
             .flat_map(|(_key, files)| files.iter().cloned())
             .collect();
 
-        let commit_result: Result<(i64, usize, i64), StorageError> = async {
+        let extra_summary = Self::snapshot_summary_from_context(&context);
+
+        let commit_result: Result<(i64, usize, i64), StorageError> = async move {
             let mut metadata = self.get_or_create_metadata(topic)?;
 
             // Calculate totals
@@ -636,6 +660,7 @@ impl IcebergStorage {
                 total_files,
                 total_rows,
                 SnapshotOperation::Append,
+                extra_summary,
             );
 
             // Write new metadata file
@@ -924,8 +949,12 @@ impl ColdStorage for IcebergStorage {
         ))
     }
 
-    async fn commit_snapshot(&self, topic: &str) -> Result<Option<i64>, StorageError> {
-        self.commit_snapshot(topic).await
+    async fn commit_snapshot(
+        &self,
+        topic: &str,
+        context: SnapshotCommitContext,
+    ) -> Result<Option<i64>, StorageError> {
+        self.commit_snapshot(topic, context).await
     }
 
     fn table_metadata_json(&self, topic: &str) -> Option<String> {
@@ -1521,10 +1550,35 @@ mod tests {
             .unwrap();
         assert_eq!(storage.pending_snapshot_stats("events").file_count, 1);
 
-        let result = storage.commit_snapshot("events").await;
+        let result = storage
+            .commit_snapshot("events", SnapshotCommitContext::default())
+            .await;
         assert!(result.is_err());
 
         // Pending files should still be present after a failed commit attempt.
         assert_eq!(storage.pending_snapshot_stats("events").file_count, 1);
+    }
+
+    #[test]
+    fn snapshot_summary_from_context_maps_watermarks() {
+        let context = SnapshotCommitContext {
+            watermarks_by_partition: HashMap::from([(0, 42), (1, 99)]),
+            high_watermarks_by_partition: HashMap::from([(0, 100), (1, 200)]),
+        };
+
+        let summary = IcebergStorage::snapshot_summary_from_context(&context);
+
+        assert_eq!(summary.get("zombi.watermark.0").unwrap(), "42");
+        assert_eq!(summary.get("zombi.watermark.1").unwrap(), "99");
+        assert_eq!(summary.get("zombi.high_watermark.0").unwrap(), "100");
+        assert_eq!(summary.get("zombi.high_watermark.1").unwrap(), "200");
+        assert_eq!(summary.len(), 4);
+    }
+
+    #[test]
+    fn snapshot_summary_from_empty_context_is_empty() {
+        let context = SnapshotCommitContext::default();
+        let summary = IcebergStorage::snapshot_summary_from_context(&context);
+        assert!(summary.is_empty());
     }
 }

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -8,7 +8,8 @@ use aws_sdk_s3::Client;
 use bytes::Bytes;
 
 use crate::contracts::{
-    ColdStorage, ColdStorageInfo, LockResultExt, SegmentInfo, StorageError, StoredEvent,
+    ColdStorage, ColdStorageInfo, LockResultExt, SegmentInfo, SnapshotCommitContext, StorageError,
+    StoredEvent,
 };
 use crate::s3_retry;
 use crate::storage::retry::RetryConfig;
@@ -299,7 +300,11 @@ impl ColdStorage for S3Storage {
         None
     }
 
-    async fn commit_snapshot(&self, _topic: &str) -> Result<Option<i64>, StorageError> {
+    async fn commit_snapshot(
+        &self,
+        _topic: &str,
+        _context: SnapshotCommitContext,
+    ) -> Result<Option<i64>, StorageError> {
         // S3 storage doesn't create Iceberg metadata
         Ok(None)
     }


### PR DESCRIPTION
## Summary

- **#109**: Each Iceberg snapshot summary now includes `zombi.watermark.{partition}` (flush boundary) and `zombi.high_watermark.{partition}` (write head at commit time), enabling offline watermark discovery without querying the live API
- **#107**: Documents the existing `ZOMBI_SNAPSHOT_MAX_AGE_SECS` env var and adds missing snapshot threshold env vars to README.md and SPEC.md config tables
- Adds typed `SnapshotCommitContext` in contracts layer; string formatting localized in `IcebergStorage`
- Guards snapshot summary: only `zombi.*` prefixed keys accepted, standard Iceberg fields protected

## Test plan

- [x] `add_snapshot_merges_extra_summary_and_drops_non_zombi_keys` — zombi keys present, non-zombi dropped, standard keys intact
- [x] `snapshot_summary_from_context_maps_watermarks` — context-to-summary conversion correctness
- [x] `snapshot_summary_from_empty_context_is_empty` — empty context edge case
- [x] `flush_now_passes_watermark_context_to_commit` — end-to-end: 2 partitions, correct flush + high watermarks in context
- [x] `age_triggered_commit_includes_watermark_context` — low-throughput (1 event, thresholds unreachable), commits by age with watermark context
- [x] Full `cargo test` — 296 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #109
Closes #107