### PR TITLE
feat: add API read enhancements (Arrow IPC, watermarks, flush wiring)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ All notable changes to Zombi are documented here.
 
 - **Table Name Validation** (Issue #101) — API rejects invalid table names at boundary (must match `^[a-zA-Z][a-zA-Z0-9_-]{0,127}$`)
 
+- **Arrow IPC Content Negotiation** — `GET /tables/{table}` supports `Accept: application/vnd.apache.arrow.stream` for Arrow IPC streaming format; includes column projection support
+
+- **Watermark Endpoint** — `GET /tables/{table}/watermark` returns per-partition flush watermark and high watermark
+
+- **Flush Wiring** — `POST /tables/{table}/flush` triggers immediate flush to cold storage (global; table-scoped planned for v0.4)
+
 ### Changed
 - **WAL enabled by default** — `ZOMBI_ROCKSDB_WAL_ENABLED` now defaults to `true` for crash-safe durability (set `false` to opt out)
 - **Hot-only HTTP reads** — `GET /tables/{table}` now reads from RocksDB hot buffer only; cold/historical reads go through Iceberg engines
@@ -63,8 +69,6 @@ All notable changes to Zombi are documented here.
   - Table name validation for safe keys/S3 paths
 - **P1 Iceberg-Native Interfaces**
   - Iceberg REST Catalog API (server-side)
-  - Arrow IPC content negotiation on read endpoint (`Accept` header)
-  - Watermark boundary endpoint
   - Watermark in snapshot summary
   - Compaction snapshot rewrite integration
   - Configurable snapshot thresholds
@@ -72,7 +76,7 @@ All notable changes to Zombi are documented here.
   - ZombiCatalog + ZombiTable + hot InputFile
   - End-to-end engine integration tests
 - **P3 Operational Maturity**
-  - Wire `/flush` and `/compact` admin endpoints
+  - Wire `/compact` admin endpoint
   - Deprecate/remove consumer offsets
   - Optional auth (token/mTLS)
 - **P4 Enhancements**

--- a/SPEC.md
+++ b/SPEC.md
@@ -496,7 +496,7 @@ Response 200:
 | Accept Header | Format | Status |
 |---------------|--------|--------|
 | `application/json` (default) | JSON object with `records`, `count`, `has_more` | Implemented |
-| `application/vnd.apache.arrow.stream` | Arrow IPC stream bytes | Planned (P1) |
+| `application/vnd.apache.arrow.stream` | Arrow IPC stream bytes | Implemented |
 
 The Arrow IPC format is designed for the ZombiCatalog plugin, which presents hot buffer data
 as Iceberg-compatible "virtual files" to query engines.
@@ -515,11 +515,6 @@ POST /consumers/{group}/commit
 GET /consumers/{group}/offset?topic=events&partition=0
 {"offset": 2000}
 ```
-
-### Planned Endpoints (Not Yet Implemented)
-
-- **Arrow IPC response format** — `Accept: application/vnd.apache.arrow.stream` on `GET /tables/{table}` for plugin reads
-- **Watermark boundary** — per-partition committed flush watermark
 
 ### Iceberg REST Catalog API (Read-Only)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -546,8 +546,9 @@ GET /health/ready              # Kubernetes readiness probe
 GET /stats                     # Server statistics (JSON)
 GET /metrics                   # Prometheus metrics format
 GET /tables/{table}/metadata   # Iceberg metadata location
+GET /tables/{table}/watermark  # Partition flush/high watermarks
 POST /tables/{table}/compact   # Trigger compaction (currently not wired)
-POST /tables/{table}/flush     # Force flush to Iceberg (currently not wired)
+POST /tables/{table}/flush     # Force flush to Iceberg (global; table-scoped planned for v0.4)
 ```
 
 #### Health Endpoints

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -98,7 +98,11 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
     get:
       summary: Read records (hot buffer; use Iceberg for analytics)
-      description: Reads from the RocksDB hot buffer only. For production analytics, query Iceberg tables directly via Spark/Trino/DuckDB.
+      description: >
+        Reads from the RocksDB hot buffer only. For production analytics, query
+        Iceberg tables directly via Spark/Trino/DuckDB. Supports content
+        negotiation via Accept header: application/json (default) or
+        application/vnd.apache.arrow.stream (Arrow IPC).
       parameters:
         - $ref: "#/components/parameters/TableParam"
         - name: since
@@ -114,6 +118,12 @@ paths:
           schema:
             type: integer
             default: 100
+        - name: fields
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Comma-separated list of columns to project (e.g. "payload,timestamp_ms")
       responses:
         "200":
           description: OK
@@ -121,6 +131,16 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReadRecordsResponse"
+            application/vnd.apache.arrow.stream:
+              schema:
+                type: string
+                format: binary
+        "406":
+          description: Not Acceptable (unsupported Accept header)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /tables/{table}/bulk:
     post:
       summary: Bulk write records
@@ -200,15 +220,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TableMetadataResponse"
-  /tables/{table}/flush:
-    post:
-      summary: Force flush to cold storage
-      description: Currently returns status "not_implemented" until the flusher is wired.
+  /tables/{table}/watermark:
+    get:
+      summary: Get partition watermarks
+      description: >
+        Returns the flush watermark (last sequence flushed to cold storage) and
+        high watermark (current write head) for each partition of the table.
+        Returns 200 with empty partitions for unknown tables (lazy creation model).
       parameters:
         - $ref: "#/components/parameters/TableParam"
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WatermarkResponse"
+  /tables/{table}/flush:
+    post:
+      summary: Force flush to cold storage
+      description: >
+        Triggers an immediate flush of pending events to cold storage.
+        Note: The current implementation performs a global flush across all topics;
+        table-scoped flush is planned for v0.4.
+      parameters:
+        - $ref: "#/components/parameters/TableParam"
+      responses:
+        "200":
+          description: Flush completed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlushResponse"
+        "503":
+          description: Flusher not configured (no cold storage)
           content:
             application/json:
               schema:
@@ -380,6 +425,26 @@ components:
         base_path:
           type: string
           nullable: true
+    WatermarkResponse:
+      type: object
+      properties:
+        topic:
+          type: string
+        partitions:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/PartitionWatermark"
+    PartitionWatermark:
+      type: object
+      properties:
+        watermark:
+          type: integer
+          format: int64
+          description: Last sequence number flushed to cold storage
+        high_watermark:
+          type: integer
+          format: int64
+          description: Highest sequence number written to hot storage
     FlushResponse:
       type: object
       properties:
@@ -387,6 +452,12 @@ components:
           type: string
         message:
           type: string
+        events_flushed:
+          type: integer
+          nullable: true
+        segments_written:
+          type: integer
+          nullable: true
     CompactResponse:
       type: object
       properties:

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -791,7 +791,7 @@ fn events_to_arrow_ipc(
     events: &[crate::contracts::StoredEvent],
     projection: &ColumnProjection,
 ) -> Result<Vec<u8>, StorageError> {
-    use arrow::array::{ArrayRef, BinaryArray, Int32Array, Int64Array, StringArray};
+    use arrow::array::{ArrayRef, BinaryArray, Int64Array, StringArray, UInt32Array, UInt64Array};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::ipc::writer::StreamWriter;
     use arrow::record_batch::RecordBatch;
@@ -806,9 +806,9 @@ fn events_to_arrow_ipc(
     let mut arrays: Vec<ArrayRef> = Vec::new();
 
     if include("sequence") {
-        schema_fields.push(Field::new("sequence", DataType::Int64, false));
-        let values: Vec<i64> = events.iter().map(|e| e.sequence as i64).collect();
-        arrays.push(Arc::new(Int64Array::from(values)));
+        schema_fields.push(Field::new("sequence", DataType::UInt64, false));
+        let values: Vec<u64> = events.iter().map(|e| e.sequence).collect();
+        arrays.push(Arc::new(UInt64Array::from(values)));
     }
 
     if include("topic") {
@@ -818,9 +818,9 @@ fn events_to_arrow_ipc(
     }
 
     if include("partition") {
-        schema_fields.push(Field::new("partition", DataType::Int32, false));
-        let values: Vec<i32> = events.iter().map(|e| e.partition as i32).collect();
-        arrays.push(Arc::new(Int32Array::from(values)));
+        schema_fields.push(Field::new("partition", DataType::UInt32, false));
+        let values: Vec<u32> = events.iter().map(|e| e.partition).collect();
+        arrays.push(Arc::new(UInt32Array::from(values)));
     }
 
     if include("timestamp_ms") {

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -11,7 +14,9 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 
-use crate::contracts::{ColdStorage, ColumnProjection, HotStorage, StorageError, KNOWN_COLUMNS};
+use crate::contracts::{
+    ColdStorage, ColumnProjection, FlushResult, HotStorage, StorageError, KNOWN_COLUMNS,
+};
 use crate::metrics::MetricsRegistry;
 use crate::proto;
 use crate::storage::WriteCombiner;
@@ -105,6 +110,16 @@ impl BackpressureConfig {
     }
 }
 
+/// Type-erased flush callback for the `/flush` endpoint.
+///
+/// The `Flusher` trait uses RPITIT and cannot be used as `dyn Flusher`.
+/// This callback wraps `Flusher::flush_now()` without requiring object safety.
+pub type FlushCallback = Arc<
+    dyn Fn() -> Pin<Box<dyn Future<Output = Result<FlushResult, StorageError>> + Send>>
+        + Send
+        + Sync,
+>;
+
 /// Application state shared across handlers.
 pub struct AppState<H: HotStorage, C: ColdStorage = NoopColdStorage> {
     pub storage: Arc<H>,
@@ -121,6 +136,8 @@ pub struct AppState<H: HotStorage, C: ColdStorage = NoopColdStorage> {
     pub write_combiner: Option<Arc<WriteCombiner<H>>>,
     /// Catalog namespace, computed once at startup from ZOMBI_CATALOG_NAMESPACE.
     pub catalog_namespace: Vec<String>,
+    /// Optional flush callback for the `/flush` endpoint
+    pub flusher: Option<FlushCallback>,
 }
 
 impl<H: HotStorage, C: ColdStorage> AppState<H, C> {
@@ -143,11 +160,17 @@ impl<H: HotStorage, C: ColdStorage> AppState<H, C> {
             max_inflight_bytes: backpressure.max_inflight_bytes as u64,
             write_combiner: None,
             catalog_namespace,
+            flusher: None,
         }
     }
 
     pub fn with_write_combiner(mut self, combiner: Option<Arc<WriteCombiner<H>>>) -> Self {
         self.write_combiner = combiner;
+        self
+    }
+
+    pub fn with_flusher(mut self, flusher: Option<FlushCallback>) -> Self {
+        self.flusher = flusher;
         self
     }
 
@@ -322,6 +345,7 @@ pub struct ErrorResponse {
 pub enum ApiError {
     Storage(StorageError),
     BadRequest(String),
+    NotAcceptable(String),
 }
 
 impl IntoResponse for ApiError {
@@ -367,6 +391,13 @@ impl IntoResponse for ApiError {
                 ErrorResponse {
                     error: msg,
                     code: "BAD_REQUEST".into(),
+                },
+            ),
+            ApiError::NotAcceptable(msg) => (
+                StatusCode::NOT_ACCEPTABLE,
+                ErrorResponse {
+                    error: msg,
+                    code: "NOT_ACCEPTABLE".into(),
                 },
             ),
         };
@@ -752,19 +783,178 @@ fn project_event(
     }
 }
 
+/// MIME type for Apache Arrow IPC streaming format.
+const ARROW_IPC_MIME: &str = "application/vnd.apache.arrow.stream";
+
+/// Converts StoredEvents to Arrow IPC stream bytes.
+fn events_to_arrow_ipc(
+    events: &[crate::contracts::StoredEvent],
+    projection: &ColumnProjection,
+) -> Result<Vec<u8>, StorageError> {
+    use arrow::array::{ArrayRef, BinaryArray, Int32Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::ipc::writer::StreamWriter;
+    use arrow::record_batch::RecordBatch;
+
+    let all_columns = projection.fields.is_none();
+    let fields_list = projection.fields.as_deref();
+    let include = |name: &str| -> bool {
+        all_columns || fields_list.is_some_and(|f| f.iter().any(|s| s == name))
+    };
+
+    let mut schema_fields = Vec::new();
+    let mut arrays: Vec<ArrayRef> = Vec::new();
+
+    if include("sequence") {
+        schema_fields.push(Field::new("sequence", DataType::Int64, false));
+        let values: Vec<i64> = events.iter().map(|e| e.sequence as i64).collect();
+        arrays.push(Arc::new(Int64Array::from(values)));
+    }
+
+    if include("topic") {
+        schema_fields.push(Field::new("topic", DataType::Utf8, false));
+        let values: Vec<&str> = events.iter().map(|e| e.topic.as_str()).collect();
+        arrays.push(Arc::new(StringArray::from(values)));
+    }
+
+    if include("partition") {
+        schema_fields.push(Field::new("partition", DataType::Int32, false));
+        let values: Vec<i32> = events.iter().map(|e| e.partition as i32).collect();
+        arrays.push(Arc::new(Int32Array::from(values)));
+    }
+
+    if include("timestamp_ms") {
+        schema_fields.push(Field::new("timestamp_ms", DataType::Int64, false));
+        let values: Vec<i64> = events.iter().map(|e| e.timestamp_ms).collect();
+        arrays.push(Arc::new(Int64Array::from(values)));
+    }
+
+    if include("payload") {
+        schema_fields.push(Field::new("payload", DataType::Binary, false));
+        let values: Vec<&[u8]> = events.iter().map(|e| e.payload.as_slice()).collect();
+        arrays.push(Arc::new(BinaryArray::from(values)));
+    }
+
+    if include("idempotency_key") {
+        schema_fields.push(Field::new("idempotency_key", DataType::Utf8, true));
+        let values: Vec<Option<&str>> = events
+            .iter()
+            .map(|e| e.idempotency_key.as_deref())
+            .collect();
+        arrays.push(Arc::new(StringArray::from(values)));
+    }
+
+    let schema = Arc::new(Schema::new(schema_fields));
+
+    let mut buf = Vec::new();
+    let mut writer = StreamWriter::try_new(&mut buf, &schema)
+        .map_err(|e| StorageError::Serialization(e.to_string()))?;
+
+    if !events.is_empty() {
+        let batch = RecordBatch::try_new(schema.clone(), arrays)
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        writer
+            .write(&batch)
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+    }
+
+    writer
+        .finish()
+        .map_err(|e| StorageError::Serialization(e.to_string()))?;
+
+    Ok(buf)
+}
+
+/// A parsed media type with its quality weight.
+struct MediaType {
+    media: String,
+    quality: f32,
+}
+
+/// Parses the Accept header into a list of media types with quality weights.
+/// E.g. "application/json; q=0.8, application/vnd.apache.arrow.stream; q=1.0"
+/// → [("application/vnd.apache.arrow.stream", 1.0), ("application/json", 0.8)]
+fn parse_accepted_media_types(accept: &str) -> Vec<MediaType> {
+    let mut types: Vec<MediaType> = accept
+        .split(',')
+        .filter_map(|part| {
+            let mut parts = part.split(';');
+            let media = parts.next()?.trim().to_lowercase();
+            if media.is_empty() {
+                return None;
+            }
+            let mut quality = 1.0f32;
+            for param in parts {
+                let param = param.trim();
+                if let Some(q) = param.strip_prefix("q=") {
+                    quality = q.trim().parse().unwrap_or(1.0);
+                }
+            }
+            Some(MediaType { media, quality })
+        })
+        .collect();
+    // Sort by quality descending (stable sort preserves order for equal q values)
+    types.sort_by(|a, b| {
+        b.quality
+            .partial_cmp(&a.quality)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    types
+}
+
 /// GET /tables/{table}
 /// Read records from the hot buffer (RocksDB only).
 /// Results are ordered by timestamp.
 /// Supports optional `fields` query parameter for column projection.
+/// Supports `Accept` header content negotiation:
+/// - `application/json` (default): JSON response
+/// - `application/vnd.apache.arrow.stream`: Arrow IPC stream
 ///
 /// Cold/historical reads go through Iceberg engines (Spark, Trino, DuckDB).
 pub async fn read_records<H: HotStorage, C: ColdStorage>(
     State(state): State<Arc<AppState<H, C>>>,
     Path(table): Path<String>,
     Query(query): Query<ReadRecordsQuery>,
-) -> Result<Json<ReadRecordsResponse>, ApiError> {
+    headers: HeaderMap,
+) -> Result<axum::response::Response, ApiError> {
     validate_table_name(&table)?;
     let start = Instant::now();
+
+    // Determine response format from Accept header
+    let accept_raw = headers
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json");
+
+    let media_types = parse_accepted_media_types(accept_raw);
+
+    // Determine preferred format based on highest-quality matching type.
+    // media_types is sorted by quality descending, so first match wins.
+    let preferred = media_types
+        .iter()
+        .find_map(|t| {
+            if t.media == ARROW_IPC_MIME {
+                Some("arrow")
+            } else if t.media == "application/json" || t.media == "*/*" {
+                Some("json")
+            } else {
+                None
+            }
+        })
+        .unwrap_or(if media_types.is_empty() {
+            "json" // No Accept header → default to JSON
+        } else {
+            "unsupported"
+        });
+
+    if preferred == "unsupported" {
+        return Err(ApiError::NotAcceptable(format!(
+            "Unsupported Accept type '{}'. Supported: application/json, {}",
+            accept_raw, ARROW_IPC_MIME
+        )));
+    }
+
+    let wants_arrow = preferred == "arrow";
 
     // Parse and validate projection
     let projection = parse_projection(&query.fields)?;
@@ -780,13 +970,7 @@ pub async fn read_records<H: HotStorage, C: ColdStorage>(
 
     let has_more = all_events.len() > query.limit;
     let events: Vec<_> = all_events.into_iter().take(query.limit).collect();
-
-    let records: Vec<serde_json::Value> = events
-        .iter()
-        .map(|e| project_event(e, &projection))
-        .collect();
-
-    let count = records.len();
+    let count = events.len();
 
     let latency_us = start.elapsed().as_micros() as u64;
     state.metrics.record_read(count as u64, latency_us);
@@ -797,11 +981,26 @@ pub async fn read_records<H: HotStorage, C: ColdStorage>(
         .enhanced_api
         .record_read(&table, latency_us);
 
-    Ok(Json(ReadRecordsResponse {
-        records,
-        count,
-        has_more,
-    }))
+    if wants_arrow {
+        let ipc_bytes = events_to_arrow_ipc(&events, &projection)?;
+        Ok(axum::response::Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, ARROW_IPC_MIME)
+            .body(axum::body::Body::from(ipc_bytes))
+            .map_err(|e| ApiError::BadRequest(format!("Failed to build response: {}", e)))?)
+    } else {
+        let records: Vec<serde_json::Value> = events
+            .iter()
+            .map(|e| project_event(e, &projection))
+            .collect();
+
+        Ok(Json(ReadRecordsResponse {
+            records,
+            count,
+            has_more,
+        })
+        .into_response())
+    }
 }
 
 /// GET /health
@@ -982,6 +1181,10 @@ pub struct TableMetadataResponse {
 pub struct FlushResponse {
     pub status: String,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events_flushed: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segments_written: Option<usize>,
 }
 
 /// Response for compact endpoint.
@@ -1024,23 +1227,111 @@ pub async fn get_table_metadata<H: HotStorage, C: ColdStorage>(
     Ok(Json(response))
 }
 
-/// POST /tables/{table}/flush
-/// Forces a flush of pending events to cold storage.
-/// Note: This endpoint requires the flusher to be wired into AppState.
-pub async fn flush_table<H: HotStorage, C: ColdStorage>(
-    State(_state): State<Arc<AppState<H, C>>>,
+/// Watermark information for a single partition.
+#[derive(Debug, Serialize)]
+pub struct PartitionWatermark {
+    /// Last sequence number successfully flushed to cold storage.
+    pub watermark: u64,
+    /// Highest sequence number written to hot storage.
+    pub high_watermark: u64,
+}
+
+/// Response for watermark endpoint.
+#[derive(Debug, Serialize)]
+pub struct WatermarkResponse {
+    pub topic: String,
+    pub partitions: HashMap<String, PartitionWatermark>,
+}
+
+/// GET /tables/{table}/watermark
+/// Returns the flush watermark and high watermark for all partitions.
+/// Returns 200 with empty partitions for unknown tables (consistent with lazy table creation).
+pub async fn get_watermark<H: HotStorage, C: ColdStorage>(
+    State(state): State<Arc<AppState<H, C>>>,
     Path(table): Path<String>,
-) -> Result<Json<FlushResponse>, ApiError> {
+) -> Result<Json<WatermarkResponse>, ApiError> {
     validate_table_name(&table)?;
-    // TODO: Wire flusher into AppState to enable this endpoint
-    // For now, return 501 Not Implemented
-    Ok(Json(FlushResponse {
-        status: "not_implemented".into(),
-        message: format!(
-            "Flush for table '{}' is not yet wired. Add flusher to AppState to enable.",
-            table
-        ),
+
+    let partitions = state.storage.list_partitions(&table).map_err(|e| {
+        state.metrics.record_error();
+        ApiError::Storage(e)
+    })?;
+
+    let mut partition_watermarks = HashMap::new();
+
+    for partition in partitions {
+        let flush_wm = state
+            .storage
+            .load_flush_watermark(&table, partition)
+            .map_err(|e| {
+                state.metrics.record_error();
+                ApiError::Storage(e)
+            })?;
+
+        let high_wm = state
+            .storage
+            .high_watermark(&table, partition)
+            .map_err(|e| {
+                state.metrics.record_error();
+                ApiError::Storage(e)
+            })?;
+
+        partition_watermarks.insert(
+            partition.to_string(),
+            PartitionWatermark {
+                watermark: flush_wm,
+                high_watermark: high_wm,
+            },
+        );
+    }
+
+    Ok(Json(WatermarkResponse {
+        topic: table,
+        partitions: partition_watermarks,
     }))
+}
+
+/// POST /tables/{table}/flush
+/// Forces an immediate flush of pending events to cold storage.
+/// Note: The current flusher flushes all topics globally; table-scoped flush is planned for v0.4.
+pub async fn flush_table<H: HotStorage, C: ColdStorage>(
+    State(state): State<Arc<AppState<H, C>>>,
+    Path(table): Path<String>,
+) -> Result<(StatusCode, Json<FlushResponse>), ApiError> {
+    validate_table_name(&table)?;
+
+    let flusher = match &state.flusher {
+        Some(f) => f,
+        None => {
+            return Ok((
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(FlushResponse {
+                    status: "not_available".into(),
+                    message: "Flusher not configured (no cold storage)".into(),
+                    events_flushed: None,
+                    segments_written: None,
+                }),
+            ));
+        }
+    };
+
+    let result = (flusher)().await.map_err(|e| {
+        state.metrics.record_error();
+        ApiError::Storage(e)
+    })?;
+
+    Ok((
+        StatusCode::OK,
+        Json(FlushResponse {
+            status: "ok".into(),
+            message: format!(
+                "Flushed {} events (global flush; table-scoped flush planned for v0.4)",
+                result.events_flushed
+            ),
+            events_flushed: Some(result.events_flushed),
+            segments_written: Some(result.segments_written),
+        }),
+    ))
 }
 
 /// POST /tables/{table}/compact

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,7 +11,8 @@ use crate::contracts::{ColdStorage, HotStorage};
 
 pub use catalog::compute_catalog_namespace;
 pub use handlers::{
-    AppState, BackpressureConfig, Metrics, NoopColdStorage, WriteRecordRequest, WriteRecordResponse,
+    AppState, BackpressureConfig, FlushCallback, Metrics, NoopColdStorage, WriteRecordRequest,
+    WriteRecordResponse,
 };
 
 /// Creates the API router.
@@ -46,6 +47,10 @@ pub fn create_router<H: HotStorage + 'static, C: ColdStorage + 'static>(
         .route(
             "/tables/:table/metadata",
             get(handlers::get_table_metadata::<H, C>),
+        )
+        .route(
+            "/tables/:table/watermark",
+            get(handlers::get_watermark::<H, C>),
         )
         .route("/tables/:table/flush", post(handlers::flush_table::<H, C>))
         .route(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ use tokio::sync::oneshot;
 use tokio::time::timeout;
 use tracing_subscriber::EnvFilter;
 
-use zombi::api::{start_server, AppState, BackpressureConfig, Metrics, ServerConfig};
+use zombi::api::{
+    start_server, AppState, BackpressureConfig, FlushCallback, Metrics, ServerConfig,
+};
 use zombi::contracts::{Flusher, TableSchemaConfig};
 use zombi::flusher::{BackgroundFlusher, FlusherConfig};
 use zombi::metrics::MetricsRegistry;
@@ -217,6 +219,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         None
     };
 
+    // Create flush callback for the /flush endpoint
+    let flush_callback: Option<FlushCallback> = flusher.as_ref().map(|f| {
+        let f = Arc::clone(f);
+        Arc::new(move || {
+            let f = Arc::clone(&f);
+            Box::pin(async move { f.flush_now().await })
+                as std::pin::Pin<
+                    Box<
+                        dyn std::future::Future<
+                                Output = Result<
+                                    zombi::contracts::FlushResult,
+                                    zombi::contracts::StorageError,
+                                >,
+                            > + Send,
+                    >,
+                >
+        }) as FlushCallback
+    });
+
     // Create app state with backpressure configuration
     let backpressure_config = BackpressureConfig::from_env();
     tracing::info!(
@@ -251,7 +272,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             backpressure_config,
             catalog_namespace,
         )
-        .with_write_combiner(write_combiner),
+        .with_write_combiner(write_combiner)
+        .with_flusher(flush_callback),
     );
 
     // Start server

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2738,6 +2738,7 @@ fn create_test_app_with_failing_flusher() -> (axum::Router, tempfile::TempDir) {
             Arc::new(Metrics::new()),
             Arc::new(MetricsRegistry::new()),
             BackpressureConfig::default(),
+            vec!["zombi".into()],
         )
         .with_flusher(Some(failing_flusher)),
     );


### PR DESCRIPTION
## Changes Summary

This PR adds three major API enhancements to enable efficient hot-buffer reads and operational monitoring:

1. **Arrow IPC Content Negotiation** (#105): Read endpoint now supports Accept header negotiation between application/json (default) and application/vnd.apache.arrow.stream for high-performance Arrow-native clients.

2. **Partition Watermark Visibility** (#108): New GET /tables/{table}/watermark endpoint exposes per-partition flush and high watermarks for monitoring lag and write progress.

3. **Functional Flush Endpoint** (#112): POST /tables/{table}/flush now wired with flusher callback, returns 503 when flusher unavailable, returns flush stats on success.

Additional fixes: removed unwrap() violation in Arrow response builder; corrected Arrow IPC types from signed Int64/Int32 to unsigned UInt64/UInt32 for sequence and partition fields (matching Parquet schema).

## Issue Reference

Closes #105
Closes #108
Closes #112

## Code Justification

**Accept header content negotiation:** Arrow IPC is an efficient columnar format for clients that already use Arrow. Quality-weight parsing (q=) follows RFC 7231 standards.

**Watermark endpoint:** Provides visibility into per-partition progress without requiring raw storage inspection. Uses existing HotStorage trait methods.

**Flush callback pattern:** Required RPITIT workaround because Flusher trait uses return position impl trait (not object-safe). Type-erased callback Arc<dyn Fn()> solves this cleanly.

**Global flush scope:** Documented as v0.3 limitation. Table-scoped flush planned for v0.4 pending partitioner design.

## Testing Done

- [x] Integration tests added/updated
- [x] All tests pass locally (`cargo test`) — 300 tests
- [x] Clippy passes (`cargo clippy -- -D warnings`)

**Test coverage:** 11 new integration tests in `tests/integration_tests.rs`:
- Arrow IPC: full schema, projection, empty results, quality-weight negotiation, 406 for unsupported types
- Watermark: after writes, unknown table returns empty
- Flush: with/without flusher configured

## Performance Impact

**Benchmarks run:** [x] N/A

No performance regressions expected. Arrow serialization is on-demand (only when Accept header requests it). Watermark endpoint uses cached partition list from RocksDB.

## Breaking Changes

- [x] Breaking changes (describe below)

Flush endpoint status code changed from 200 ("not_implemented" stub) to 503 ("not_available" when no flusher). Previously was a non-functional stub.

## Documentation Updated

- [x] SPEC.md updated (if API/architecture change)
- [x] Code comments added for non-obvious logic
- OpenAPI spec (docs/openapi.yaml) updated with all new endpoints and schemas

## Pre-Submission Checklist

- [x] All tests pass (`cargo test`)
- [x] Linting passes (`cargo clippy -- -D warnings`)
- [x] Formatting is correct (`cargo fmt --check`)
- [x] Issue is linked in PR description
- [x] Code justification provided (for significant changes)
- [x] Commit messages follow convention (type(scope): subject)